### PR TITLE
#1：Cloneしてきた状態でアプリケーションを起動すると、エラーがでる

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,14 +8,18 @@ function App() {
   const [notes, setNotes] = useState(
     JSON.parse(localStorage.getItem("notes")) || []
   );
-  const [activeNote, setActiveNote] = useState(false);
+  const [activeNote, setActiveNote] = useState(null);
 
   useEffect(() => {
     localStorage.setItem("notes", JSON.stringify(notes));
   }, [notes]);
 
   useEffect(() => {
-    setActiveNote(notes[0].id);
+    if (notes.length > 0) {
+      setActiveNote(notes[0].id);
+    } else {
+      setActiveNote(null);
+    }
   }, []);
 
   const onAddNote = () => {


### PR DESCRIPTION
activeNoteの初期値に"false"よりも好ましい"null"を設定するように修正しました。 
useEffectの初回レンダリングにノートが一冊もない場合、初期値にnullを設定することで対応した。